### PR TITLE
Remove duplicate mask applying on ENTER press

### DIFF
--- a/maskedtextfield-addon/assembly/MANIFEST.MF
+++ b/maskedtextfield-addon/assembly/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Vaadin-Package-Version: 1
+Vaadin-Addon: ${Vaadin-Addon}
+Vaadin-License-Title: ${Vaadin-License-Title}
+Implementation-Vendor: ${Implementation-Vendor}
+Implementation-Title: ${Implementation-Title}
+Implementation-Version: ${Implementation-Version}

--- a/maskedtextfield-addon/assembly/assembly.xml
+++ b/maskedtextfield-addon/assembly/assembly.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly
+	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	<id>addon</id>
+
+	<!-- Note: the base directory for this assembly descriptor is one of the 
+		license specific subprojects -->
+
+	<formats>
+		<format>zip</format>
+	</formats>
+
+	<!-- Do not use because we must put META-INF/MANIFEST.MF there. -->
+	<includeBaseDirectory>false</includeBaseDirectory>
+
+	<fileSets>
+		<fileSet>
+			<directory>..</directory>
+			<includes>
+				<include>LICENSE.txt</include>
+				<include>README.md</include>
+			</includes>
+		</fileSet>
+		<fileSet>
+			<directory>target</directory>
+			<outputDirectory></outputDirectory>
+			<includes>
+				<include>*.jar</include>
+                <include>*.pdf</include>
+			</includes>
+		</fileSet>
+	</fileSets>
+
+	<files>
+		<!-- This is vaadin.com/directory related manifest needed in the zip package -->
+		<file>
+			<source>assembly/MANIFEST.MF</source>
+			<outputDirectory>META-INF</outputDirectory>
+			<filtered>true</filtered>
+		</file>
+	</files>
+</assembly>

--- a/maskedtextfield-addon/pom.xml
+++ b/maskedtextfield-addon/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.addons</groupId>
 	<artifactId>maskedtextfield</artifactId>
 	<packaging>jar</packaging>
-	<version>0.4.0</version>
+	<version>0.5.0</version>
 	<name>MaskedTextField for Vaadin 8 Add-on</name>
 
 	<prerequisites>

--- a/maskedtextfield-addon/src/main/java/org/vaadin/addons/maskedtextfield/client/MaskedTextFieldWidget.java
+++ b/maskedtextfield-addon/src/main/java/org/vaadin/addons/maskedtextfield/client/MaskedTextFieldWidget.java
@@ -99,6 +99,8 @@ public class MaskedTextFieldWidget extends VTextField implements KeyDownHandler,
 	}
 
 	private void configureMask() {
+		maskTest.clear();
+		string = new StringBuilder();
 		for (int index = 0; index < mask.length(); index++) {
 			char character = mask.charAt(index);
 			createCorrectMaskAndPlaceholder(character, index);
@@ -306,6 +308,8 @@ public class MaskedTextFieldWidget extends VTextField implements KeyDownHandler,
 		} else if (event.getNativeKeyCode() == KeyCodes.KEY_ENTER) {
 			if(isFieldIfIncomplete()) {
 				cleanText();
+				setMask(mask);
+				setCursorPos(getAvaliableCursorPos(0));
 			}
 			//super.onKeyDown(event);
 		} else {

--- a/maskedtextfield-demo/pom.xml
+++ b/maskedtextfield-demo/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.addons</groupId>
 	<artifactId>maskedtextfield-demo</artifactId>
 	<packaging>war</packaging>
-	<version>0.4.0</version>
+	<version>0.5.0</version>
 	<name>MaskedTextField for Vaadin 8 Demo</name>
 
 	<prerequisites>

--- a/maskedtextfield-demo/src/main/java/org/vaadin/addons/demo/DemoUI.java
+++ b/maskedtextfield-demo/src/main/java/org/vaadin/addons/demo/DemoUI.java
@@ -31,9 +31,7 @@ public class DemoUI extends UI
     protected void init(VaadinRequest request) {
         final MaskedTextField maskedTextField = new MaskedTextField("Masked field", "###-###-###");
         maskedTextField.addValueChangeListener(event -> System.out.println("New value of the masked field: " + maskedTextField.getValue()));
-        maskedTextField.setMask("##-##-##");
-        maskedTextField.setValue("454545454");
-        //maskedTextField.setPlaceHolder(' ');
+        maskedTextField.setMask("(###) ###-####");
         maskedTextField.setPlaceHolder('\0');
 
         final DecimalField decimalField = new DecimalField("Decimal field");

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>maskedtextfield-root</artifactId>
 	<packaging>pom</packaging>
 	<version>MaskedTextField for Vaadin 8</version>
-	<name>0.4.0</name>
+	<name>0.5.0</name>
 
 	<prerequisites>
 		<maven>3</maven>


### PR DESCRIPTION
 -When enter is pressed in the masked field without value,the mask was re-applied twice. Proper resetting of the value.
- Adding missing assembly file to the /addon project
- Version increase to 0.5.0